### PR TITLE
added setSat(255) for the StateUpdate

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/hue_light/LightController.java
+++ b/src/main/java/org/jenkinsci/plugins/hue_light/LightController.java
@@ -64,7 +64,7 @@ public class LightController {
         if (null == this.hueBridge || null == light || null == color)
             return false;
 
-        StateUpdate stateUpdate = new StateUpdate().turnOn().setBrightness(255).setHue(color.getHue());
+        StateUpdate stateUpdate = new StateUpdate().turnOn().setBrightness(255).setSat(255).setHue(color.getHue());
 
         try {
             this.hueBridge.setLightState(light, stateUpdate);


### PR DESCRIPTION
Thank you for putting together this plugin...I love it!  I did notice that "out of the box" the saturation is not set very high on my Hue bulbs.  I couldn't figure out why the colors were so faint.  We have lots of bright white lights in the office, so the colors were very difficult to see.

I played around with setting the saturation, and that seemed to be the trick.

Possible alternatives - add saturation/brightness as a field in Jenkins, and use 255 as the defaults.
